### PR TITLE
Remove extraneous orig call, and use a case insensitive string compare

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -20,14 +20,13 @@ google-deeplink
 	NSArray *googleScs = @[@"google",@"googleapp",@"googlemobileurl",@"google-deeplink"];
 	
 	for (NSString* str in googleScs){
-		if ([[url path] rangeOfString:str].location != NSNotFound) {
+		if ([[url path] localizedCaseInsensitiveContainsString:str]) {
 			return NO;
 		}
 	}
 	
 	
 	
-	%orig;
 	return %orig;
 }
 


### PR DESCRIPTION
Remove the non-returning `orig` call. 

Use a case insensitive compare, as URL schemes on iOS are case insensitive. 